### PR TITLE
Fix Dockerfile build with dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,14 @@ WORKDIR /usr/src/app
 
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm install --production
+# Install all dependencies so that the TypeScript build can run
+RUN npm ci
+
+# Copy the rest of the application code
 COPY . .
+
+# Compile the TypeScript sources
 RUN npm run build
+
+# Remove development dependencies to keep the image slim
+RUN npm prune --omit=dev


### PR DESCRIPTION
## Summary
- ensure Dockerfile installs dev dependencies for building

## Testing
- `npm run build` *(fails: Cannot find module '@vendure/core' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68446dfb6ee48321b54f53a9ebfcd5a9