### PR TITLE
Add BullMQ queue plugin

### DIFF
--- a/.env
+++ b/.env
@@ -9,3 +9,5 @@ DB_NAME=vendure
 DB_USERNAME=need-it
 DB_PASSWORD=zsolika
 DB_SCHEMA=public
+REDIS_HOST=localhost
+REDIS_PORT=6379

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ docker-compose up postgres_db
 docker-compose up redis
 ```
 
+The project uses the BullMQ-based JobQueue plugin. Make sure the `bullmq` and `@vendure/job-queue-plugin`
+packages are installed before building the Docker image:
+
+```bash
+npm install @vendure/job-queue-plugin bullmq
+```
+
+Redis connection parameters can be configured with the `REDIS_HOST` and `REDIS_PORT` environment variables
+(see [.env](./.env) for defaults).
+
 ## Plugins
 
 In Vendure, your custom functionality will live in [plugins](https://www.vendure.io/docs/plugins/).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "@vendure/core": "3.3.1",
     "@vendure/email-plugin": "3.3.1",
     "@vendure/graphiql-plugin": "3.3.1",
+    "@vendure/job-queue-plugin": "3.3.1",
+    "bullmq": "4.10.0",
     "dotenv": "16.5.0",
     "pg": "8.16.0"
   },

--- a/src/environment.d.ts
+++ b/src/environment.d.ts
@@ -16,6 +16,8 @@ declare global {
             DB_USERNAME: string;
             DB_PASSWORD: string;
             DB_SCHEMA: string;
+            REDIS_HOST?: string;
+            REDIS_PORT?: number;
         }
     }
 }

--- a/src/vendure-config.ts
+++ b/src/vendure-config.ts
@@ -1,10 +1,10 @@
 import {
     dummyPaymentHandler,
-    DefaultJobQueuePlugin,
     DefaultSchedulerPlugin,
     DefaultSearchPlugin,
     VendureConfig,
 } from '@vendure/core';
+import { BullMQJobQueuePlugin } from '@vendure/job-queue-plugin/package/bullmq/plugin';
 import { defaultEmailHandlers, EmailPlugin, FileBasedTemplateLoader } from '@vendure/email-plugin';
 import { AssetServerPlugin } from '@vendure/asset-server-plugin';
 import { AdminUiPlugin } from '@vendure/admin-ui-plugin';
@@ -69,7 +69,12 @@ export const config: VendureConfig = {
             assetUrlPrefix: IS_DEV ? undefined : 'https://www.my-shop.com/assets/',
         }),
         DefaultSchedulerPlugin.init(),
-        DefaultJobQueuePlugin.init({ useDatabaseForBuffer: true }),
+        BullMQJobQueuePlugin.init({
+            connection: {
+                host: process.env.REDIS_HOST || 'localhost',
+                port: +(process.env.REDIS_PORT || 6379),
+            },
+        }),
         DefaultSearchPlugin.init({ bufferUpdates: false, indexStockStatus: true }),
         EmailPlugin.init({
             devMode: true,


### PR DESCRIPTION
## Summary
- support BullMQ-based job queues
- document required dependencies and Redis settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c4d38a2148321990fa762a2cfb288